### PR TITLE
docs: 📝 #2 OpenAPI定義を記述

### DIFF
--- a/Sources/EXWebAPI/openapi.yaml
+++ b/Sources/EXWebAPI/openapi.yaml
@@ -1,0 +1,24 @@
+openapi: 3.1.0
+info:
+  title: Todo API
+  description: API for managing Todo items
+  version: 1.0.0
+paths:
+  /api/todo:
+    post:
+      summary: Create a new Todo
+      description: Creates a new Todo with default values
+      operationId: createTodo
+      responses:
+        '201':
+          description: Todo created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                required:
+                  - id


### PR DESCRIPTION
# 概要
このPull Requestでは、新しいAPI仕様書openapi.yamlが追加されています。この仕様書は「Todo API」の定義を行い、新規のTodoを作成するためのエンドポイントを含んでいます。
openapi.yamlファイルにOpenAPI 3.1.0形式のAPI定義が追加されました。
APIは/api/todoエンドポイントを提供し、新しいTodoを作成する操作を定義しています。
正常なリクエストに対して、HTTPステータス201でTodo作成成功のレスポンスを返します。
レスポンスには必須フィールドとしてid（UUID形式）が含まれます。