### PR TITLE
docs: 📝 #3 OpenAPI定義にGET /api/todo/{id}を記述

### DIFF
--- a/Sources/EXWebAPI/openapi.yaml
+++ b/Sources/EXWebAPI/openapi.yaml
@@ -22,3 +22,57 @@ paths:
                     format: uuid
                 required:
                   - id
+  /api/todo/{id}:
+    get:
+      summary: Get a Todo by ID
+      description: Retrieves a Todo item by its ID
+      operationId: getTodoById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of the Todo to retrieve
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Todo retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  title:
+                    type: string
+                  description:
+                    type: string
+                required:
+                  - id
+                  - title
+                  - description
+        '404':
+          description: Todo not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                required:
+                  - error
+        '400':
+          description: Invalid UUID format
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                required:
+                  - error


### PR DESCRIPTION
Summary
このPRでは、/api/todo/{id} エンドポイントが新規追加され、特定のTodoアイテムをIDで取得する機能が実装されています。また、リクエストおよびレスポンスの構造が詳細に定義されています。
/api/todo/{id} エンドポイントの追加: IDを用いて単一のTodoアイテムを取得。
HTTPレスポンスコード(200, 404, 400)の詳細な説明を含む。
入力パラメータのバリデーション（UUID形式）と、そのエラーハンドリングの定義。
応答として返されるデータのスキーマを定義（id, title, description を含む）。

Fixed #3 